### PR TITLE
Reverse proxy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,16 @@
+localhost
+
+# server reverse proxy
+# strips the prefix and sends to flask server
+# the prefix is /s
+# this is to distinguish stuff
+route /s/* {
+        uri strip_prefix /s
+        reverse_proxy localhost:5000
+}
+
+# client server reverse proxy
+# this is used for a file server
+route /* {
+      reverse_proxy localhost:3000
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # UwinRent
 
+## Requirements
+
+
+## Steps
+
 steps that the server undertakes when getting a request from a browser
 
 1. browser sends GET / to server

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
 # UwinRent
 
 ## Requirements
+* <MAIN>/server Requirements
+* <MAIN>/client Requirements
+* Caddyserver2 
+
+## How to run - dev
+
+1. Follow <MAIN>/server startup steps
+
+2. Follow <MAIN>/client startup steps
+
+3. in `<MAIN>` run `sudo caddy start`
+   now at https://localhost:80 the app is running
 
 
-## Steps
+## Sequence diagram 
 
 steps that the server undertakes when getting a request from a browser
 

--- a/server/README.md
+++ b/server/README.md
@@ -5,6 +5,7 @@
 ## Technologies overview
 * Ariadne - Graphql
 * Flask - Web Server
+* Gunicorn - Reverse Proxy Entry Point
 
 ## structure overview
 
@@ -15,6 +16,11 @@
 * python 3.8+
 * pyvenv
 * pip
+
+#### Update Requirements
+
+run `pip freeze > requirements.txt`
+
 
 ### Setup
 
@@ -42,4 +48,4 @@
 
 3. Actually run the code
    
-   run `python3 app.py`
+   run `gunicorn --bind 127.0.0.1:5000 wsgi:app`

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,6 +2,7 @@ ariadne==0.12.0
 click==7.1.2
 Flask==1.1.2
 graphql-core==3.0.5
+gunicorn==20.0.4
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1

--- a/server/wsgi.py
+++ b/server/wsgi.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
### What are you trying to accomplish?
create a reverse proxy to "marry" <MAIN>/server and <MAIN>/client and get them to work under the same URL

add ssl and https

### How are you accomplishing it?
setup gunicorn as a wsgi gateway

using caddy server as the major server to manage connections and reverse proxy

caddy server is filtering for routes
all server routes will be under `/s/*` and everything else will be under `/*`
this is done because the <MAIN>/client is similar to a file server. so having it as `/*` to return files 

### Is there anything reviewers should know?

there will eventually be instructions for production services and using docker instead of having it "uncontainered"

- [ ] Is it safe to rollback this change if anything goes wrong?
technically yes but it needs to be done eventually or the whole thing wont work
