### PR TITLE
fixes fatal error

### DIFF
--- a/tests/installGeckoDriver.bash
+++ b/tests/installGeckoDriver.bash
@@ -6,8 +6,6 @@ tar -xvzf geckodriver-v0.28.0-linux64.tar.gz
 
 chmod +x geckodriver
 
-sudo mv geckodriver /usr/local/bin
+sudo mv geckodriver /usr/local/bin/geckodriver
 
 rm geckodriver-v0.28.0-linux64.tar.gz
-
-clear


### PR DESCRIPTION
### What are you trying to accomplish?
there is a fatal error with the `mv` command that was there

it would overwrite anything in `/usr/local/bin`

### How are you accomplishing it?
change it to create a file **in** `/usr/local/bin` instead of at `/usr/local/bin`

### Is there anything reviewers should know?

i also got rid of `clear` cause its weird for a script to do that IMO


- [x] Is it safe to rollback this change if anything goes wrong?
